### PR TITLE
Update advices regarding Schema conformation.

### DIFF
--- a/docs/.vuepress/navbar/en.ts
+++ b/docs/.vuepress/navbar/en.ts
@@ -28,6 +28,11 @@ export const enNavbar = navbar([
         link: "https://github.com/Kamisato-Ayaka-233/mihoyo-api-collect",
         icon: "repo",
       },
+      {
+        text: "Schema Verify Tool",
+        link: "https://schema.uigf.org/",
+        icon: "tool"
+      }
     ],
   },
 ]);

--- a/docs/.vuepress/navbar/en.ts
+++ b/docs/.vuepress/navbar/en.ts
@@ -29,7 +29,7 @@ export const enNavbar = navbar([
         icon: "repo",
       },
       {
-        text: "Schema Verify Tool",
+        text: "UIGF Schema Verify Tool",
         link: "https://schema.uigf.org/",
         icon: "tool"
       }

--- a/docs/.vuepress/navbar/zh.ts
+++ b/docs/.vuepress/navbar/zh.ts
@@ -28,6 +28,11 @@ export const zhNavbar = navbar([
         link: "/zh/mihoyo-api-collection-project.html",
         icon: "api",
       },
+      {
+        text: "UIGF 格式合规性校验工具",
+        link: "https://schema.uigf.org/",
+        icon: "tool"
+      }
     ],
   },
 ]);

--- a/docs/.vuepress/navbar/zh.ts
+++ b/docs/.vuepress/navbar/zh.ts
@@ -29,7 +29,7 @@ export const zhNavbar = navbar([
         icon: "api",
       },
       {
-        text: "UIGF 格式合规性校验工具",
+        text: "UIGF 格式校验工具",
         link: "https://schema.uigf.org/",
         icon: "tool"
       }

--- a/docs/en/standards/srgf.md
+++ b/docs/en/standards/srgf.md
@@ -54,7 +54,7 @@ Devs are strongly urged to respect the data types of each property in the schema
 
 To avoid such issues, we recommend designing dedicated structs for the SRGF format or utilizing methods like `JsonNumberHandling.WriteAsString`. Additionally, it is advisable to design relevant unit tests to ensure consistency between imports and exports.
 
-We also provide the [SRGF Json Schema Verify Tool](https://schema.uigf.org/) to help you to verify validation of Json files.
+We also provide the [SRGF Json Schema Verify Tool](https://schema.uigf.org/?schema=srgf) to help you to verify validation of Json files.
 :::
 
 ```json

--- a/docs/en/standards/srgf.md
+++ b/docs/en/standards/srgf.md
@@ -49,14 +49,12 @@ Including only importing feature reduces the interchangeability of user data, an
 
 ## Json Schema
 
-::: warning WARNING
-Devs are strongly urged to respect the data types of each property in the schema. Especially, please do not use Int for those String fields.
+::: warning Mind the Field Types
+Devs are strongly urged to respect the data types of each property in the schema. Using incorrect types could result in errors when parsing JSON files by other tools developed in strong typing programming languages, leading to data transfer failures.
 
-Any disrespect of such can result in forcing the devs of other apps to wipe your arse.
+Use of dedicated structs (in lieu of inheritable classes) is strongly recommended for UIGF exports in order to avoid such kind of troubles. You may also take advantages of some in-language features like `JsonNumberHandling.WriteAsString` in C#. Use dedicated unit tests to make sure the consistency between the exported and the imported data.
 
-Use of dedicated structs (in lieu of inheritable classes) is strongly recommended for SRGF exports in order to avoid such kind of troubles. You may also take advantages of some in-language features like `JsonNumberHandling.WriteAsString` in C#. Use dedicated unit tests to make sure the consistency between the exported and the imported data.
-
-Furthermore, here are the [Json Schema Validation Utilities](https://github.com/UIGF-org/UIGF-SchemaVerify).
+Additionally, we provide the [SRGF Json Schema Verify Tool](https://schema.uigf.org/).
 :::
 
 ```json

--- a/docs/en/standards/srgf.md
+++ b/docs/en/standards/srgf.md
@@ -49,6 +49,16 @@ Including only importing feature reduces the interchangeability of user data, an
 
 ## Json Schema
 
+::: warning WARNING
+Devs are strongly urged to respect the data types of each property in the schema. Especially, please do not use Int for those String fields.
+
+Any disrespect of such can result in forcing the devs of other apps to wipe your arse.
+
+Use of dedicated structs (in lieu of inheritable classes) is strongly recommended for SRGF exports in order to avoid such kind of troubles. You may also take advantages of some in-language features like `JsonNumberHandling.WriteAsString` in C#. Use dedicated unit tests to make sure the consistency between the exported and the imported data.
+
+Furthermore, here are the [Json Schema Validation Utilities](https://github.com/UIGF-org/UIGF-SchemaVerify).
+:::
+
 ```json
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
@@ -122,7 +132,7 @@ Including only importing feature reduces the interchangeability of user data, an
           },
           "time": {
             "type": "string",
-            "description": "Time of item achieved"
+            "description": "Time when the item was obtained. This MUST BE THE String typed value captured intact from the gacha record webpage WITHOUT ANY CONVERTION TO ANY DATE TYPES. Any conversion of such can cause potential timezone mistakes if the device time zone differs from the server time zone, unless special treatments are applied by individual app devs."
           },
           "name": {
             "type": "string",

--- a/docs/en/standards/srgf.md
+++ b/docs/en/standards/srgf.md
@@ -52,9 +52,9 @@ Including only importing feature reduces the interchangeability of user data, an
 ::: warning Mind the Field Types
 Devs are strongly urged to respect the data types of each property in the schema. Using incorrect types could result in errors when parsing JSON files by other tools developed in strong typing programming languages, leading to data transfer failures.
 
-Use of dedicated structs (in lieu of inheritable classes) is strongly recommended for UIGF exports in order to avoid such kind of troubles. You may also take advantages of some in-language features like `JsonNumberHandling.WriteAsString` in C#. Use dedicated unit tests to make sure the consistency between the exported and the imported data.
+To avoid such issues, we recommend designing dedicated structs for the SRGF format or utilizing methods like `JsonNumberHandling.WriteAsString`. Additionally, it is advisable to design relevant unit tests to ensure consistency between imports and exports.
 
-Additionally, we provide the [SRGF Json Schema Verify Tool](https://schema.uigf.org/).
+We also provide the [SRGF Json Schema Verify Tool](https://schema.uigf.org/) to help you to verify validation of Json files.
 :::
 
 ```json

--- a/docs/en/standards/uiaf.md
+++ b/docs/en/standards/uiaf.md
@@ -38,6 +38,14 @@ All time in this standard are based on `UTC+8` time zone
 
 ## Json Schema
 
+::: warning Mind the Field Types
+Devs are strongly urged to respect the data types of each property in the schema. Using incorrect types could result in errors when parsing JSON files by other tools developed in strong typing programming languages, leading to data transfer failures.
+
+To avoid such issues, we recommend designing dedicated structs for the UIAF format or utilizing methods like `JsonNumberHandling.WriteAsString`. Additionally, it is advisable to design relevant unit tests to ensure consistency between imports and exports.
+
+We also provide the [UIAF Json Schema Verify Tool](https://schema.uigf.org/?schema=uiaf) to help you to verify validation of Json files.
+:::
+
 ```json
 {
   "$schema": "http://json-schema.org/draft-04/schema#",

--- a/docs/en/standards/uigf-legacy-v2.3.md
+++ b/docs/en/standards/uigf-legacy-v2.3.md
@@ -140,7 +140,7 @@ Item's in-game ID, refer to [UIGF API](../API.md) to get this data
             },
             "time": {
               "type": "string",
-              "title": "Time of item achieved"
+              "title": "Time when the item was obtained. "
             },
             "name": {
               "type": "string",

--- a/docs/en/standards/uigf.md
+++ b/docs/en/standards/uigf.md
@@ -90,9 +90,9 @@ Item's in-game ID, refer to [UIGF API](../API.md) to get this data.
 ::: warning Mind the Field Types
 Devs are strongly urged to respect the data types of each property in the schema. Using incorrect types could result in errors when parsing JSON files by other tools developed in strong typing programming languages, leading to data transfer failures.
 
-Use of dedicated structs (in lieu of inheritable classes) is strongly recommended for UIGF exports in order to avoid such kind of troubles. You may also take advantages of some in-language features like `JsonNumberHandling.WriteAsString` in C#. Use dedicated unit tests to make sure the consistency between the exported and the imported data.
+To avoid such issues, we recommend designing dedicated structs for the UIGF format or utilizing methods like `JsonNumberHandling.WriteAsString`. Additionally, it is advisable to design relevant unit tests to ensure consistency between imports and exports.
 
-Additionally, we provide the [UIGF Json Schema Verify Tool](https://schema.uigf.org/).
+We also provide the [UIGF Json Schema Verify Tool](https://schema.uigf.org/) to help you to verify validation of Json files.
 :::
 
 ```json

--- a/docs/en/standards/uigf.md
+++ b/docs/en/standards/uigf.md
@@ -87,14 +87,12 @@ Item's in-game ID, refer to [UIGF API](../API.md) to get this data.
 
 > UIGF-Org provides the following JSON Schema for the validation of the data structure.
 
-::: warning WARNING
-Devs are strongly urged to respect the data types of each property in the schema. Especially, please do not use Int for those String fields.
-
-Any disrespect of such can result in forcing the devs of other apps to wipe your arse.
+::: warning Mind the Field Types
+Devs are strongly urged to respect the data types of each property in the schema, which means use the expected `type`. Using incorrect types can result in errors when parsing JSON files by other tools developed in strong typing programming languages, leading to data transfer failures.
 
 Use of dedicated structs (in lieu of inheritable classes) is strongly recommended for UIGF exports in order to avoid such kind of troubles. You may also take advantages of some in-language features like `JsonNumberHandling.WriteAsString` in C#. Use dedicated unit tests to make sure the consistency between the exported and the imported data.
 
-Furthermore, here are the [Json Schema Validation Utilities](https://github.com/UIGF-org/UIGF-SchemaVerify).
+Furthermore, here are the [UIGF Json Schema Verify Tool](https://schema.uigf.org/).
 :::
 
 ```json

--- a/docs/en/standards/uigf.md
+++ b/docs/en/standards/uigf.md
@@ -88,11 +88,11 @@ Item's in-game ID, refer to [UIGF API](../API.md) to get this data.
 > UIGF-Org provides the following JSON Schema for the validation of the data structure.
 
 ::: warning Mind the Field Types
-Devs are strongly urged to respect the data types of each property in the schema, which means use the expected `type`. Using incorrect types can result in errors when parsing JSON files by other tools developed in strong typing programming languages, leading to data transfer failures.
+Devs are strongly urged to respect the data types of each property in the schema. Using incorrect types could result in errors when parsing JSON files by other tools developed in strong typing programming languages, leading to data transfer failures.
 
 Use of dedicated structs (in lieu of inheritable classes) is strongly recommended for UIGF exports in order to avoid such kind of troubles. You may also take advantages of some in-language features like `JsonNumberHandling.WriteAsString` in C#. Use dedicated unit tests to make sure the consistency between the exported and the imported data.
 
-Furthermore, here are the [UIGF Json Schema Verify Tool](https://schema.uigf.org/).
+Additionally, we provide the [UIGF Json Schema Verify Tool](https://schema.uigf.org/).
 :::
 
 ```json

--- a/docs/en/standards/uigf.md
+++ b/docs/en/standards/uigf.md
@@ -92,7 +92,7 @@ Devs are strongly urged to respect the data types of each property in the schema
 
 To avoid such issues, we recommend designing dedicated structs for the UIGF format or utilizing methods like `JsonNumberHandling.WriteAsString`. Additionally, it is advisable to design relevant unit tests to ensure consistency between imports and exports.
 
-We also provide the [UIGF Json Schema Verify Tool](https://schema.uigf.org/) to help you to verify validation of Json files.
+We also provide the [UIGF Json Schema Verify Tool](https://schema.uigf.org/?schema=uigf) to help you to verify validation of Json files.
 :::
 
 ```json

--- a/docs/en/standards/uigf.md
+++ b/docs/en/standards/uigf.md
@@ -81,11 +81,21 @@ Please remember to add corresponding uigf_gacha_type field when applying UIGF fo
 
 ### `item_id`
 
-Item's in-game ID, refer to [UIGF API](../API.md) to get this data
+Item's in-game ID, refer to [UIGF API](../API.md) to get this data.
 
 ## Json Schema
 
-> UIGF-Org provides [Json Schema](/schema/uigf.json) for validation
+> UIGF-Org provides the following JSON Schema for the validation of the data structure.
+
+::: warning WARNING
+Devs are strongly urged to respect the data types of each property in the schema. Especially, please do not use Int for those String fields.
+
+Any disrespect of such can result in forcing the devs of other apps to wipe your arse.
+
+Use of dedicated structs (in lieu of inheritable classes) is strongly recommended for UIGF exports in order to avoid such kind of troubles. You may also take advantages of some in-language features like `JsonNumberHandling.WriteAsString` in C#. Use dedicated unit tests to make sure the consistency between the exported and the imported data.
+
+Furthermore, here are the [Json Schema Validation Utilities](https://github.com/UIGF-org/UIGF-SchemaVerify).
+:::
 
 ```json
 {
@@ -156,7 +166,7 @@ Item's in-game ID, refer to [UIGF API](../API.md) to get this data
           },
           "time": {
             "type": "string",
-            "title": "Time when the item was obtained"
+            "title": "Time when the item was obtained. This MUST BE THE String typed value captured intact from the gacha record webpage WITHOUT ANY CONVERTION TO ANY DATE TYPES. Any conversion of such can cause potential timezone mistakes if the device time zone differs from the server time zone, unless special treatments are applied by individual app devs."
           },
           "name": {
             "type": "string",

--- a/docs/zh/standards/srgf.md
+++ b/docs/zh/standards/srgf.md
@@ -48,6 +48,16 @@ head:
 
 ## Json Schema
 
+::: warning 警告
+请各位开发者务必尊重 Schema 内定义的资料类型。该是 String 的请一定不要用 Int 凑合。
+
+任何此类行为都等价于让其他支持 SRGF 的 App 开发者们替您擦屁股。
+
+为了规避这类问题，您或许可以针对 SRGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
+
+此外，这里也有 [Json 格式合规性校验工具](https://github.com/UIGF-org/UIGF-SchemaVerify) 可用。
+:::
+
 ```json
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
@@ -121,7 +131,7 @@ head:
           },
           "time": {
             "type": "string",
-            "description": "获取物品的时间"
+            "description": "获取物品的时间，应为「抽卡记录网页上写的原始时间字串值 (String)」而非任何读取转换过的值。任何此般类型转换，但凡设备时区与伺服器时区有异，便一定会出现时区转换误差（除非开发者有做过专门的应对措施）。"
           },
           "name": {
             "type": "string",

--- a/docs/zh/standards/srgf.md
+++ b/docs/zh/standards/srgf.md
@@ -48,14 +48,12 @@ head:
 
 ## Json Schema
 
-::: warning 警告
-请各位开发者务必尊重 Schema 内定义的资料类型。该是 String 的请一定不要用 Int 凑合。
+::: warning 注意字段类型
+请各位开发者务必尊重 Schema 内定义的字段类型。使用错误的类型可能会导致其它由强类型编程语言制成的工具在解析 Json 文件时产生错误，进而导致数据转移失败。
 
-任何此类行为都等价于让其他支持 SRGF 的 App 开发者们替您擦屁股。
+为了规避这类问题，您或许可以针对 UIGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
 
-为了规避这类问题，您或许可以针对 SRGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
-
-此外，这里也有 [Json 格式合规性校验工具](https://github.com/UIGF-org/UIGF-SchemaVerify) 可用。
+同时，我们也提供 [SRGF 格式校验工具](https://schema.uigf.org/)。
 :::
 
 ```json

--- a/docs/zh/standards/srgf.md
+++ b/docs/zh/standards/srgf.md
@@ -53,7 +53,7 @@ head:
 
 为了避免这类问题，我们建议您针对 SRGF 格式设计专用的 struct，或善用 `JsonNumberHandling.WriteAsString` 等方法。同时，设计相关的单元测试以确保导入导出的一致性。
 
-我们也提供 [SRGF 格式校验工具](https://schema.uigf.org/)来帮助你校验 Json 文件。
+我们也提供 [SRGF 格式校验工具](https://schema.uigf.org/?schema=srgf)来帮助你校验 Json 文件。
 :::
 
 ```json
@@ -129,7 +129,7 @@ head:
           },
           "time": {
             "type": "string",
-            "description": "获取物品的时间，应为「抽卡记录网页上写的原始时间字串值 (String)」而非任何读取转换过的值。任何此般类型转换，但凡设备时区与伺服器时区有异，便一定会出现时区转换误差（除非开发者有做过专门的应对措施）。"
+            "description": "获取物品的时间，应为「抽卡记录网页上显示的原始时间字符串」而非任何转换过的值。如果设备时区与服务器时区不一致，任意类型转换将会导致时区转换出现误差（除非应用进行了特殊处理）。"
           },
           "name": {
             "type": "string",

--- a/docs/zh/standards/srgf.md
+++ b/docs/zh/standards/srgf.md
@@ -51,9 +51,9 @@ head:
 ::: warning 注意字段类型
 请各位开发者务必尊重 Schema 内定义的字段类型。使用错误的类型可能会导致其它由强类型编程语言制成的工具在解析 Json 文件时产生错误，进而导致数据转移失败。
 
-为了规避这类问题，您或许可以针对 UIGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
+为了避免这类问题，我们建议您针对 SRGF 格式设计专用的 struct，或善用 `JsonNumberHandling.WriteAsString` 等方法。同时，设计相关的单元测试以确保导入导出的一致性。
 
-同时，我们也提供 [SRGF 格式校验工具](https://schema.uigf.org/)。
+我们也提供 [SRGF 格式校验工具](https://schema.uigf.org/)来帮助你校验 Json 文件。
 :::
 
 ```json

--- a/docs/zh/standards/uiaf.md
+++ b/docs/zh/standards/uiaf.md
@@ -38,6 +38,14 @@ head:
 
 ## Json Schema
 
+::: warning 注意字段类型
+请各位开发者务必尊重 Schema 内定义的字段类型。使用错误的类型可能会导致其它由强类型编程语言制成的工具在解析 Json 文件时产生错误，进而导致数据转移失败。
+
+为了避免这类问题，我们建议您针对 UIAF 格式设计专用的 struct，或善用 `JsonNumberHandling.WriteAsString` 等方法。同时，设计相关的单元测试以确保导入导出的一致性。
+
+我们也提供 [UIAF 格式校验工具](https://schema.uigf.org/?schema=uiaf)来帮助你校验 Json 文件。
+:::
+
 ```json
 {
   "$schema": "http://json-schema.org/draft-04/schema#",

--- a/docs/zh/standards/uigf.md
+++ b/docs/zh/standards/uigf.md
@@ -84,11 +84,11 @@ App 不应假定 `region_time_zone` 的值为上表中给出的值，应具有�
 > UIGF-Org 提供下述 Json Schema 以用于验证资料结构的正确性。
 
 ::: warning 注意字段类型
-请各位开发者务必尊重 Schema 内定义的字段类型，即使用预期内的 `type`。使用错误的类型会导致其它由强类型编程语言制成的工具在解析 Json 文件时产生错误，进而导致数据转移失败。
+请各位开发者务必尊重 Schema 内定义的字段类型。使用错误的类型可能会导致其它由强类型编程语言制成的工具在解析 Json 文件时产生错误，进而导致数据转移失败。
 
 为了规避这类问题，您或许可以针对 UIGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
 
-此外，这里也有 [Json 格式合规性校验工具](https://schema.uigf.org/) 可用。
+同时，我们也提供 [UIGF 格式校验工具](https://schema.uigf.org/)。
 :::
 
 ```json

--- a/docs/zh/standards/uigf.md
+++ b/docs/zh/standards/uigf.md
@@ -88,7 +88,7 @@ App 不应假定 `region_time_zone` 的值为上表中给出的值，应具有�
 
 为了避免这类问题，我们建议您针对 UIGF 格式设计专用的 struct，或善用 `JsonNumberHandling.WriteAsString` 等方法。同时，设计相关的单元测试以确保导入导出的一致性。
 
-我们也提供 [UIGF 格式校验工具](https://schema.uigf.org/)来帮助你校验 Json 文件。
+我们也提供 [UIGF 格式校验工具](https://schema.uigf.org/?schema=uigf)来帮助你校验 Json 文件。
 :::
 
 ```json
@@ -160,7 +160,7 @@ App 不应假定 `region_time_zone` 的值为上表中给出的值，应具有�
           },
           "time": {
             "type": "string",
-            "description": "获取物品的时间，应为「抽卡记录网页上写的原始时间字串值 (String)」而非任何读取转换过的值。任何此般类型转换，但凡设备时区与伺服器时区有异，便一定会出现时区转换误差（除非开发者有做过专门的应对措施）。"
+            "description": "获取物品的时间，应为「抽卡记录网页上显示的原始时间字符串」而非任何转换过的值。如果设备时区与服务器时区不一致，任意类型转换将会导致时区转换出现误差（除非应用进行了特殊处理）。"
           },
           "name": {
             "type": "string",

--- a/docs/zh/standards/uigf.md
+++ b/docs/zh/standards/uigf.md
@@ -83,14 +83,12 @@ App 不应假定 `region_time_zone` 的值为上表中给出的值，应具有�
 
 > UIGF-Org 提供下述 Json Schema 以用于验证资料结构的正确性。
 
-::: warning 警告
-请各位开发者务必尊重 Schema 内定义的资料类型。该是 String 的请一定不要用 Int 凑合。
-
-任何此类行为都等价于让其他支持 UIGF 的 App 开发者们替您擦屁股。
+::: warning 注意字段类型
+请各位开发者务必尊重 Schema 内定义的字段类型，即使用预期内的 `type`。使用错误的类型会导致其它由强类型编程语言制成的工具在解析 Json 文件时产生错误，进而导致数据转移失败。
 
 为了规避这类问题，您或许可以针对 UIGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
 
-此外，这里也有 [Json 格式合规性校验工具](https://github.com/UIGF-org/UIGF-SchemaVerify) 可用。
+此外，这里也有 [Json 格式合规性校验工具](https://schema.uigf.org/) 可用。
 :::
 
 ```json

--- a/docs/zh/standards/uigf.md
+++ b/docs/zh/standards/uigf.md
@@ -63,7 +63,7 @@ App 不应假定 `region_time_zone` 的值为上表中给出的值，应具有�
 
 由于存在会共享保底与概率的卡池，所以需要一个额外的字段来界定  
 我们在 `UIGF` 的所有格式中注入了 `uigf_gacha_type` 字段  
-在导出到 `UIGF` 格式时需要注意添加对应的 `uigf_gacha_type` 字段  
+在导出到 `UIGF` 格式时需要注意添加对应的 `uigf_gacha_type` 字段。
 
 #### 映射关系
 
@@ -77,11 +77,21 @@ App 不应假定 `region_time_zone` 的值为上表中给出的值，应具有�
 
 ### `item_id`
 
-物品游戏内ID，你可以通过 [UIGF API](../api.md) 获取这一数据
+物品游戏内ID，你可以通过 [UIGF API](../api.md) 获取这一数据。
 
 ## Json Schema
 
-> UIGF-Org 提供[Json Schema](/schema/uigf.json) 用于验证
+> UIGF-Org 提供下述 Json Schema 以用于验证资料结构的正确性。
+
+::: warning 警告
+请各位开发者务必尊重 Schema 内定义的资料类型。该是 String 的请一定不要用 Int 凑合。
+
+任何此类行为都等价于让其他支持 UIGF 的 App 开发者们替您擦屁股。
+
+为了规避这类问题，您或许可以针对 UIGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
+
+此外，这里也有 [Json 格式合规性校验工具](https://github.com/UIGF-org/UIGF-SchemaVerify) 可用。
+:::
 
 ```json
 {
@@ -152,7 +162,7 @@ App 不应假定 `region_time_zone` 的值为上表中给出的值，应具有�
           },
           "time": {
             "type": "string",
-            "title": "获取物品的时间"
+            "description": "获取物品的时间，应为「抽卡记录网页上写的原始时间字串值 (String)」而非任何读取转换过的值。任何此般类型转换，但凡设备时区与伺服器时区有异，便一定会出现时区转换误差（除非开发者有做过专门的应对措施）。"
           },
           "name": {
             "type": "string",

--- a/docs/zh/standards/uigf.md
+++ b/docs/zh/standards/uigf.md
@@ -86,9 +86,9 @@ App 不应假定 `region_time_zone` 的值为上表中给出的值，应具有�
 ::: warning 注意字段类型
 请各位开发者务必尊重 Schema 内定义的字段类型。使用错误的类型可能会导致其它由强类型编程语言制成的工具在解析 Json 文件时产生错误，进而导致数据转移失败。
 
-为了规避这类问题，您或许可以针对 UIGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
+为了避免这类问题，我们建议您针对 UIGF 格式设计专用的 struct，或善用 `JsonNumberHandling.WriteAsString` 等方法。同时，设计相关的单元测试以确保导入导出的一致性。
 
-同时，我们也提供 [UIGF 格式校验工具](https://schema.uigf.org/)。
+我们也提供 [UIGF 格式校验工具](https://schema.uigf.org/)来帮助你校验 Json 文件。
 :::
 
 ```json


### PR DESCRIPTION
1. 新增段落、以对不遵守资料类型的行为进行是正劝说。（已更新）

> ::: warning 警告
> 请各位开发者务必尊重 Schema 内定义的资料类型。该是 String 的请一定不要用 Int 凑合。
> 
> 任何此类行为都等价于让其他支持 UIGF 的 App 开发者们替您擦屁股。
> 
> 为了规避这类问题，您或许可以针对 UIGF 资料导出的需求设计专用的 Struct（而非与其他 Class 互为继承关系）、或善用「JsonNumberHandling.WriteAsString」等手段，且设计专门的单元测试、以确保导出与导入时的资料的一致性。
> 
> 此外，这里也有 [Json 格式合规性校验工具](https://github.com/UIGF-org/UIGF-SchemaVerify) 可用。
> :::

2. 补充说明了 GachaItem list 子类型当中的 time 栏位该填写怎样的数据：

> 「获取物品的时间，应为「抽卡记录网页上写的原始时间字串值 (String)」而非任何读取转换过的值。任何此般类型转换，但凡设备时区与伺服器时区有异，便一定会出现时区转换误差（除非开发者有做过专门的应对措施）。」