### PR TITLE
✏️ schema没有enumDesc关键字

### DIFF
--- a/docs/en/standards/uiaf.md
+++ b/docs/en/standards/uiaf.md
@@ -93,14 +93,13 @@ We also provide the [UIAF Json Schema Verify Tool](https://schema.uigf.org/?sche
           },
           "status": {
             "type": "number",
-            "description": "Finished status",
+            "description": "Finished status:ACHIEVEMENT_INVALID = 0; ACHIEVEMENT_UNFINISHED = 1; ACHIEVEMENT_FINISHED = 2;ACHIEVEMENT_POINT_TAKEN = 3;",
             "enum": [
               0,
               1,
               2,
               3
-            ],
-            "enumDesc": "ACHIEVEMENT_INVALID = 0; ACHIEVEMENT_UNFINISHED = 1; ACHIEVEMENT_FINISHED = 2;ACHIEVEMENT_POINT_TAKEN = 3;"
+            ]
           },
           "timestamp": {
             "type": "number",

--- a/docs/zh/standards/uiaf.md
+++ b/docs/zh/standards/uiaf.md
@@ -93,14 +93,13 @@ head:
           },
           "status": {
             "type": "number",
-            "description": "完成状态",
+            "description": "完成状态:ACHIEVEMENT_INVALID = 0; ACHIEVEMENT_UNFINISHED = 1; ACHIEVEMENT_FINISHED = 2;ACHIEVEMENT_POINT_TAKEN = 3;",
             "enum": [
               0,
               1,
               2,
               3
-            ],
-            "enumDesc": "ACHIEVEMENT_INVALID = 0; ACHIEVEMENT_UNFINISHED = 1; ACHIEVEMENT_FINISHED = 2;ACHIEVEMENT_POINT_TAKEN = 3;"
+            ]
           },
           "timestamp": {
             "type": "number",


### PR DESCRIPTION
根据 [JSON Schema规范](https://json-schema.apifox.cn/#%E9%80%9A%E7%94%A8%E5%85%B3%E9%94%AE%E5%AD%97)，其中并不包括 `enumDesc` 关键字，故将内容移至 `description` 之中