### PR TITLE
genshin-wish-export has added support for v4.1

### DIFF
--- a/docs/en/partnership-list.md
+++ b/docs/en/partnership-list.md
@@ -236,6 +236,22 @@
       <Pcb label="UIGF v4.1" :games="['ys']" bg="blue"></Pcb>
     </template>
   </Pcd>
+  <Pcd
+    bg="https://img.alicdn.com/imgextra/i3/1797064093/O1CN018VkZBw1g6dvTMaX9W_!!1797064093.png"
+    icon="https://s1.ax1x.com/2023/09/09/pP6xBef.png"
+    repo="https://github.com/biuuu/genshin-wish-export"
+    title="genshin wish export"
+    desc="Easily export the Genshin Impact wish record"
+    import export>
+    <template #import>
+      <Pcb label="UIGF v4.1" :games="['ys']" bg="blue"></Pcb>
+      <Pcb label="UIGF v3.0" :games="['ys']" bg="white"></Pcb>
+    </template>
+    <template #export>
+      <Pcb label="UIGF v4.1" :games="['ys']" bg="blue"></Pcb>
+      <Pcb label="UIGF v3.0" :games="['ys']" bg="white"></Pcb>
+    </template>
+  </Pcd>
 </RelativeProjectPanel>
 
 ## Projects with UIAF Standard
@@ -333,17 +349,6 @@
 ## Projects with Deprecated Standards
 
 <RelativeProjectPanel>
-  <Pcd
-    bg="https://img.alicdn.com/imgextra/i3/1797064093/O1CN018VkZBw1g6dvTMaX9W_!!1797064093.png"
-    icon="https://s1.ax1x.com/2023/09/09/pP6xBef.png"
-    repo="https://github.com/biuuu/genshin-wish-export"
-    title="genshin wish export"
-    desc="Easily export the Genshin Impact wish record"
-    export>
-    <template #export>
-      <Pcb label="UIGF v3.0" :games="['ys']" bg="white"></Pcb>
-    </template>
-  </Pcd>
   <Pcd
     bg="https://file.xunkong.cc/static/repo/xunkong/YanfeiLawyer.webp"
     icon="https://xunkong.cc/images/logo.640.webp"

--- a/docs/zh/partnership-list.md
+++ b/docs/zh/partnership-list.md
@@ -236,6 +236,22 @@
       <Pcb label="UIGF v4.1" :games="['ys']" bg="blue"></Pcb>
     </template>
   </Pcd>
+  <Pcd
+    bg="https://img.alicdn.com/imgextra/i3/1797064093/O1CN018VkZBw1g6dvTMaX9W_!!1797064093.png"
+    icon="https://s1.ax1x.com/2023/09/09/pP6xBef.png"
+    repo="https://github.com/biuuu/genshin-wish-export"
+    title="genshin wish export"
+    desc="原神祈愿记录导出工具"
+    import export>
+    <template #import>
+      <Pcb label="UIGF v4.1" :games="['ys']" bg="blue"></Pcb>
+      <Pcb label="UIGF v3.0" :games="['ys']" bg="white"></Pcb>
+    </template>
+    <template #export>
+      <Pcb label="UIGF v4.1" :games="['ys']" bg="blue"></Pcb>
+      <Pcb label="UIGF v3.0" :games="['ys']" bg="white"></Pcb>
+    </template>
+  </Pcd>
 </RelativeProjectPanel>
 
 ## 使用 UIAF 标准的项目
@@ -333,17 +349,6 @@
 ## 使用已弃用标准的项目
 
 <RelativeProjectPanel>
-  <Pcd
-    bg="https://img.alicdn.com/imgextra/i3/1797064093/O1CN018VkZBw1g6dvTMaX9W_!!1797064093.png"
-    icon="https://s1.ax1x.com/2023/09/09/pP6xBef.png"
-    repo="https://github.com/biuuu/genshin-wish-export"
-    title="genshin wish export"
-    desc="Easily export the Genshin Impact wish record"
-    export>
-    <template #export>
-      <Pcb label="UIGF v3.0" :games="['ys']" bg="white"></Pcb>
-    </template>
-  </Pcd>
   <Pcd
     bg="https://file.xunkong.cc/static/repo/xunkong/YanfeiLawyer.webp"
     icon="https://xunkong.cc/images/logo.640.webp"


### PR DESCRIPTION
genshin-wish-export [已经支持了UIGFv4.1版本](https://github.com/biuuu/genshin-wish-export/commit/609f37467d1667283779f249267238fb9212f880)

<img width="1119" height="807" alt="image" src="https://github.com/user-attachments/assets/791ed23c-f1cb-4247-8176-522fc8514f2e" />


[UIGF_v4.1_100456880_202601150056.json](https://github.com/user-attachments/files/24619972/UIGF_v4.1_100456880_202601150056.json)
