### PR TITLE
[Partnership] Moanlog (墨安云端记录) - UIGF v4.2, ys/sr/zzz

### DIFF
--- a/docs/.vuepress/public/partnerships/moanlog/logo.svg
+++ b/docs/.vuepress/public/partnerships/moanlog/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="24" fill="url(#g)"/>
+  <text x="60" y="78" font-family="serif" font-size="52" font-weight="bold" fill="white" text-anchor="middle">墨</text>
+</svg>

--- a/docs/.vuepress/public/partnerships/moanlog/preview.svg
+++ b/docs/.vuepress/public/partnerships/moanlog/preview.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#f0f4f8" rx="8"/>
+  <!-- nav bar -->
+  <rect width="600" height="50" fill="rgba(255,255,255,.85)" rx="8"/>
+  <rect x="16" y="12" width="30" height="26" rx="6" fill="#2563eb"/>
+  <text x="52" y="32" font-family="sans-serif" font-size="16" font-weight="700" fill="#1e293b">墨安云端记录</text>
+  <!-- tabs -->
+  <rect x="16" y="66" width="80" height="32" rx="8" fill="#2563eb"/>
+  <text x="38" y="86" font-family="sans-serif" font-size="13" fill="white" font-weight="600">总览</text>
+  <rect x="104" y="66" width="80" height="32" rx="8" fill="#fff" stroke="#e2e8f0"/>
+  <text x="126" y="86" font-family="sans-serif" font-size="13" fill="#475569">抽卡数据</text>
+  <!-- card -->
+  <rect x="16" y="114" width="568" height="80" rx="12" fill="white" stroke="#e2e8f0"/>
+  <text x="32" y="140" font-family="sans-serif" font-size="14" font-weight="700" fill="#0f172a">📊 数据概览</text>
+  <rect x="32" y="152" width="80" height="24" rx="6" fill="#dbeafe"/>
+  <text x="42" y="169" font-family="sans-serif" font-size="11" fill="#1d4ed8">抽卡记录</text>
+  <!-- stats -->
+  <rect x="32" y="184" width="200" height="50" rx="8" fill="#f8fafc" stroke="#e2e8f0"/>
+  <text x="50" y="206" font-family="sans-serif" font-size="12" fill="#64748b">总记录数</text>
+  <text x="50" y="224" font-family="sans-serif" font-size="18" font-weight="700" fill="#0f172a">45,678</text>
+  <!-- footer -->
+  <rect x="0" y="372" width="600" height="28" fill="#fff"/>
+  <text x="300" y="390" font-family="sans-serif" font-size="11" fill="#94a3b8" text-anchor="middle">墨安云端记录 · 遵循 UIGF 标准</text>
+</svg>

--- a/docs/en/partnership-list.md
+++ b/docs/en/partnership-list.md
@@ -277,6 +277,21 @@
       <Pcb label="UIGF v4.1" :games="['ys']" bg="blue"></Pcb>
     </template>
   </Pcd>
+  <Pcd
+    bg="/partnerships/moanlog/preview.svg"
+    icon="/partnerships/moanlog/logo.svg"
+    repo="https://github.com/Muoan/Moanlog"
+    site="https://record.muoan.com"
+    title="Moanlog"
+    desc="Gacha Record Management Tool with UIGF v4.2 import/export and QR scan auto-fetch."
+    import export>
+    <template #import>
+      <Pcb label="UIGF v4.2" :games="['ys', 'sr', 'zzz']" bg="blue"></Pcb>
+    </template>
+    <template #export>
+      <Pcb label="UIGF v4.2" :games="['ys', 'sr', 'zzz']" bg="blue"></Pcb>
+    </template>
+  </Pcd>
 </RelativeProjectPanel>
 
 ## Projects with UIAF Standard

--- a/docs/zh/partnership-list.md
+++ b/docs/zh/partnership-list.md
@@ -275,6 +275,21 @@
       <Pcb label="UIGF v4.1" :games="['ys']" bg="blue"></Pcb>
     </template>
   </Pcd>
+  <Pcd
+    bg="/partnerships/moanlog/preview.svg"
+    icon="/partnerships/moanlog/logo.svg"
+    repo="https://github.com/Muoan/Moanlog"
+    site="https://record.muoan.com"
+    title="墨安云端记录"
+    desc="抽卡记录管理工具，支持UIGF v4.2导入导出和扫码自动拉取功能。"
+    import export>
+    <template #import>
+      <Pcb label="UIGF v4.2" :games="['ys', 'sr', 'zzz']" bg="blue"></Pcb>
+    </template>
+    <template #export>
+      <Pcb label="UIGF v4.2" :games="['ys', 'sr', 'zzz']" bg="blue"></Pcb>
+    </template>
+  </Pcd>
 </RelativeProjectPanel>
 
 ## 使用 UIAF 标准的项目


### PR DESCRIPTION
## Project Info

- **Name**: Moanlog (墨安云端记录)
- **Site**: https://record.muoan.com
- **Repo**: https://github.com/Muoan/Moanlog
- **UIGF**: v4.2
- **Games**: ys, sr, zzz
- **Import/Export**: Full support

Moanlog is an online gacha record management tool supporting UIGF v4.2 import/export for Genshin Impact, Honkai: Star Rail, and Zenless Zone Zero, with miHoYo QR scan auto-fetch functionality.